### PR TITLE
fix CI build+push workflow?

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,14 @@
-name: Build
+name: 🚀 Release
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.ref_name }}_${{ github.workflow }}
+  cancel-in-progress: false
 
 jobs:
   build:
-    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
     - name: 'Checkout GitHub Action'


### PR DESCRIPTION
the workflow is being skipped even when you make a release

not sure what's going on, but porting over a working spec from the python template