### PR TITLE
Emit per-job resource metrics, and include more labels on the per-job metrics

### DIFF
--- a/internal/collector/account.go
+++ b/internal/collector/account.go
@@ -42,14 +42,6 @@ func NewAccountCollector(slurmClient client.Client) prometheus.Collector {
 			// Other States
 			Hold: prometheus.NewDesc("slurm_account_jobs_hold_total", "Number of account jobs with Hold flag", accountLabels, nil),
 		},
-		JobTres: jobTresCollector{
-			// CPUs
-			CpusAlloc: prometheus.NewDesc("slurm_account_jobs_cpus_alloc_total", "Number of Allocated CPUs among account jobs", accountLabels, nil),
-			// Memory
-			MemoryAlloc: prometheus.NewDesc("slurm_account_jobs_memory_alloc_total", "Amount of Allocated Memory (bytes) among account jobs", accountLabels, nil),
-			// GPUs
-			GpusAlloc: prometheus.NewDesc("slurm_account_jobs_gpus_alloc_total", "Number of Allocated GPUs among account jobs", accountLabels, nil),
-		},
 	}
 }
 
@@ -58,7 +50,6 @@ type accountCollector struct {
 
 	JobCount  *prometheus.Desc
 	JobStates jobStatesCollector
-	JobTres   jobTresCollector
 }
 
 func (c *accountCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -96,10 +87,6 @@ func (c *accountCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.JobStates.Configuring, prometheus.GaugeValue, float64(data.JobStates.Configuring), account)
 		ch <- prometheus.MustNewConstMetric(c.JobStates.PowerUpNode, prometheus.GaugeValue, float64(data.JobStates.PowerUpNode), account)
 		ch <- prometheus.MustNewConstMetric(c.JobStates.Hold, prometheus.GaugeValue, float64(data.JobStates.Hold), account)
-		// Tres
-		ch <- prometheus.MustNewConstMetric(c.JobTres.CpusAlloc, prometheus.GaugeValue, float64(data.JobTres.CpusAlloc), account)
-		ch <- prometheus.MustNewConstMetric(c.JobTres.MemoryAlloc, prometheus.GaugeValue, float64(data.JobTres.MemoryAlloc), account)
-		ch <- prometheus.MustNewConstMetric(c.JobTres.GpusAlloc, prometheus.GaugeValue, float64(data.JobTres.GpusAlloc), account)
 	}
 }
 
@@ -123,7 +110,6 @@ func calculateAccountMetrics(jobList *types.V0041JobInfoList) *AccountMetrics {
 		}
 		metrics.JobMetricsPer[key].JobCount++
 		calculateJobState(&metrics.JobMetricsPer[key].JobStates, job)
-		calculateJobTres(&metrics.JobMetricsPer[key].JobTres, job)
 	}
 	return metrics
 }

--- a/internal/collector/account_test.go
+++ b/internal/collector/account_test.go
@@ -58,7 +58,6 @@ func TestAccountCollector_getAccountMetrics(t *testing.T) {
 					"root": {
 						JobCount:  2,
 						JobStates: JobStates{Running: 2},
-						JobTres:   JobTres{CpusAlloc: 20, MemoryAlloc: 4096 * 1024 * 1024, GpusAlloc: 6},
 					},
 				},
 			},
@@ -88,7 +87,6 @@ func TestAccountCollector_getAccountMetrics(t *testing.T) {
 			opts := []cmp.Option{
 				cmpopts.IgnoreUnexported(AccountMetrics{}),
 				cmpopts.IgnoreFields(JobStates{}, "total"),
-				cmpopts.IgnoreFields(JobTres{}, "total"),
 			}
 			if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
 				t.Errorf("accountCollector.getAccountMetrics() = (-want,+got):\n%s", diff)

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -16,5 +16,5 @@ var (
 
 	combinedStateLabels = []string{"node", "combined_state"}
 
-	jobLabels = []string{"job_id", "job_name", "node"}
+	jobLabels = []string{"job_id", "job_name", "node", "account", "partition", "user_id", "user_name"}
 )

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -195,69 +195,73 @@ func (c *jobCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, jobState := range metrics.JobIndividualStates {
 		jobID := jobState.JobID
 		jobName := jobState.JobName
+		account := jobState.Account
+		partition := jobState.Partition
+		userID := jobState.UserID
+		userName := jobState.UserName
 		for _, node := range jobState.Nodes {
 			// Individual Job State Metrics ------------------------------------
 			// Only emit when state is active (value = 1) for cardinality reasons.
 
 			// Base States
 			if jobState.BootFail == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateBootFail, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateBootFail, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Cancelled == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateCancelled, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateCancelled, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Completed == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateCompleted, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateCompleted, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Deadline == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateDeadline, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateDeadline, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Failed == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateFailed, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateFailed, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Pending == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStatePending, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStatePending, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Preempted == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStatePreempted, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStatePreempted, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Running == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateRunning, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateRunning, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Suspended == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateSuspended, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateSuspended, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Timeout == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateTimeout, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateTimeout, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.NodeFail == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateNodeFail, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateNodeFail, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.OutOfMemory == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateOutOfMemory, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateOutOfMemory, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			// Flag States
 			if jobState.Completing == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateCompleting, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateCompleting, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.Configuring == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateConfiguring, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateConfiguring, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.PowerUpNode == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStatePowerUpNode, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStatePowerUpNode, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			if jobState.StageOut == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateStageOut, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateStageOut, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 			// Other States
 			if jobState.Hold == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateHold, prometheus.GaugeValue, 1, jobID, jobName, node)
+				ch <- prometheus.MustNewConstMetric(c.JobStateHold, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
 			}
 
 			// Individual Job Tres Metrics -------------------------------------
-			ch <- prometheus.MustNewConstMetric(c.JobTres.CpusAlloc, prometheus.GaugeValue, float64(jobState.CpusAlloc), jobID, jobName, node)
-			ch <- prometheus.MustNewConstMetric(c.JobTres.MemoryAlloc, prometheus.GaugeValue, float64(jobState.MemoryAlloc), jobID, jobName, node)
-			ch <- prometheus.MustNewConstMetric(c.JobTres.GpusAlloc, prometheus.GaugeValue, float64(jobState.GpusAlloc), jobID, jobName, node)
+			ch <- prometheus.MustNewConstMetric(c.JobTres.CpusAlloc, prometheus.GaugeValue, float64(jobState.CpusAlloc), jobID, jobName, node, account, partition, userID, userName)
+			ch <- prometheus.MustNewConstMetric(c.JobTres.MemoryAlloc, prometheus.GaugeValue, float64(jobState.MemoryAlloc), jobID, jobName, node, account, partition, userID, userName)
+			ch <- prometheus.MustNewConstMetric(c.JobTres.GpusAlloc, prometheus.GaugeValue, float64(jobState.GpusAlloc), jobID, jobName, node, account, partition, userID, userName)
 		}
 	}
 }
@@ -272,28 +276,22 @@ func (c *jobCollector) getJobMetrics(ctx context.Context) (*JobMetrics, error) {
 }
 
 func calculateJobMetrics(jobList *types.V0041JobInfoList) *JobMetrics {
+	// Collective Metrics
 	metrics := &JobMetrics{
 		JobCount:            uint(len(jobList.Items)),
 		JobIndividualStates: make([]JobIndividualStates, 0, len(jobList.Items)),
 	}
+
+	// Individual job metrics
 	for _, job := range jobList.Items {
 		calculateJobState(&metrics.JobStates, job)
-		calculateJobTres(&metrics.JobTres, job)
-		// Calculate individual job states and TRES
 		jobStates := calculateJobIndividualStates(job)
 		if jobStates != nil {
 			metrics.JobIndividualStates = append(metrics.JobIndividualStates, *jobStates)
 		}
 	}
-	return metrics
-}
 
-func calculateJobTres(metrics *JobTres, job types.V0041JobInfo) {
-	metrics.total++
-	res := getJobResourceAlloc(job)
-	metrics.CpusAlloc += res.Cpus
-	metrics.MemoryAlloc += res.Memory
-	metrics.GpusAlloc += res.Gpus
+	return metrics
 }
 
 func calculateJobState(metrics *JobStates, job types.V0041JobInfo) {
@@ -377,7 +375,6 @@ func getJobResourceAlloc(job types.V0041JobInfo) jobResources {
 type JobMetrics struct {
 	JobCount            uint
 	JobStates           JobStates
-	JobTres             JobTres
 	JobIndividualStates []JobIndividualStates
 }
 
@@ -407,21 +404,14 @@ type JobStates struct {
 	Hold uint
 }
 
-// JobTres holds the total allocated resources across all jobs in the cluster
-type JobTres struct {
-	total uint
-	// CPUs
-	CpusAlloc uint
-	// Memory
-	MemoryAlloc uint
-	// GPUs
-	GpusAlloc uint
-}
-
 type JobIndividualStates struct {
-	JobID   string
-	JobName string
-	Nodes   []string
+	JobID     string
+	JobName   string
+	Nodes     []string
+	Account   string
+	Partition string
+	UserID    string
+	UserName  string
 	// Base States
 	BootFail    int
 	Cancelled   int
@@ -442,7 +432,7 @@ type JobIndividualStates struct {
 	StageOut    int
 	// Other States
 	Hold int
-	// TRES
+	// Tres
 	CpusAlloc   uint
 	MemoryAlloc uint
 	GpusAlloc   uint
@@ -466,9 +456,13 @@ func calculateJobIndividualStates(job types.V0041JobInfo) *JobIndividualStates {
 	}
 
 	jobStates := &JobIndividualStates{
-		JobID:   jobID,
-		JobName: jobName,
-		Nodes:   nodes,
+		JobID:     jobID,
+		JobName:   jobName,
+		Nodes:     nodes,
+		Account:   ptr.Deref(job.Account, ""),
+		Partition: ptr.Deref(job.Partition, ""),
+		UserID:    fmt.Sprintf("%d", ptr.Deref(job.UserId, 0)),
+		UserName:  ptr.Deref(job.UserName, ""),
 	}
 
 	// Base States
@@ -526,7 +520,7 @@ func calculateJobIndividualStates(job types.V0041JobInfo) *JobIndividualStates {
 		jobStates.Hold = 1
 	}
 
-	// Get TRES allocations for this job
+	// Get Tres allocations for this job
 	res := getJobResourceAlloc(job)
 	jobStates.CpusAlloc = res.Cpus
 	jobStates.MemoryAlloc = res.Memory

--- a/internal/collector/job_test.go
+++ b/internal/collector/job_test.go
@@ -79,87 +79,6 @@ func Test_getJobResourceAlloc(t *testing.T) {
 	}
 }
 
-func Test_calculateJobTres(t *testing.T) {
-	type args struct {
-		job types.V0041JobInfo
-	}
-	tests := []struct {
-		name string
-		args args
-		want *JobTres
-	}{
-		{
-			name: "empty",
-			args: args{
-				job: types.V0041JobInfo{},
-			},
-			want: &JobTres{},
-		},
-		{
-			name: "job with resources",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobResources: &api.V0041JobRes{
-						Nodes: &struct {
-							Allocation *api.V0041JobResNodes             "json:\"allocation,omitempty\""
-							Count      *int32                            "json:\"count,omitempty\""
-							List       *string                           "json:\"list,omitempty\""
-							SelectType *[]api.V0041JobResNodesSelectType "json:\"select_type,omitempty\""
-							Whole      *bool                             "json:\"whole,omitempty\""
-						}{
-							Allocation: &api.V0041JobResNodes{
-								{
-									Cpus: &struct {
-										Count *int32 "json:\"count,omitempty\""
-										Used  *int32 "json:\"used,omitempty\""
-									}{
-										Count: ptr.To[int32](16),
-									},
-									Memory: &struct {
-										Allocated *int64 "json:\"allocated,omitempty\""
-										Used      *int64 "json:\"used,omitempty\""
-									}{
-										Allocated: ptr.To[int64](2048),
-									},
-								},
-							},
-						},
-					},
-					TresAllocStr: ptr.To("cpu=16,mem=2048M,node=1,billing=16,gres/gpu=4"),
-				}},
-			},
-			want: &JobTres{
-				CpusAlloc:   16,
-				MemoryAlloc: 2048 * 1024 * 1024,
-				GpusAlloc:   4,
-			},
-		},
-		{
-			name: "job with GPU only",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					TresAllocStr: ptr.To("gres/gpu=8"),
-				}},
-			},
-			want: &JobTres{
-				GpusAlloc: 8,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			metrics := &JobTres{}
-			calculateJobTres(metrics, tt.args.job)
-			opts := []cmp.Option{
-				cmpopts.IgnoreUnexported(JobTres{}),
-			}
-			if diff := cmp.Diff(tt.want, metrics, opts...); diff != "" {
-				t.Errorf("calculateJobTres() = (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func Test_calculateJobState(t *testing.T) {
 	type args struct {
 		job types.V0041JobInfo
@@ -403,12 +322,11 @@ func TestJobCollector_getJobMetrics(t *testing.T) {
 			want: &JobMetrics{
 				JobCount:  4,
 				JobStates: JobStates{Pending: 2, Running: 2, Hold: 1},
-				JobTres:   JobTres{CpusAlloc: 20, MemoryAlloc: 4096 * 1024 * 1024, GpusAlloc: 6},
 				JobIndividualStates: []JobIndividualStates{
-					{JobID: "0", JobName: "test_job_0", Nodes: []string{"node1"}, Running: 1, CpusAlloc: 8, MemoryAlloc: 1024 * 1024 * 1024, GpusAlloc: 2},
-					{JobID: "1", JobName: "test_job_1", Nodes: []string{""}, Pending: 1, Hold: 1, CpusAlloc: 0, MemoryAlloc: 0, GpusAlloc: 0},
-					{JobID: "2", JobName: "test_job_2", Nodes: []string{"node2", "node3"}, Running: 1, CpusAlloc: 12, MemoryAlloc: 3072 * 1024 * 1024, GpusAlloc: 4},
-					{JobID: "3", JobName: "test_job_3", Nodes: []string{""}, Pending: 1, CpusAlloc: 0, MemoryAlloc: 0, GpusAlloc: 0},
+					{JobID: "0", JobName: "test_job_0", Nodes: []string{"node1"}, Account: "root", Partition: "blue", UserID: "0", UserName: "root", Running: 1, CpusAlloc: 8, MemoryAlloc: 1024 * 1024 * 1024, GpusAlloc: 2},
+					{JobID: "1", JobName: "test_job_1", Nodes: []string{""}, Account: "", Partition: "blue,green", UserID: "0", UserName: "root", Pending: 1, Hold: 1, CpusAlloc: 0, MemoryAlloc: 0, GpusAlloc: 0},
+					{JobID: "2", JobName: "test_job_2", Nodes: []string{"node2", "node3"}, Account: "root", Partition: "green", UserID: "1000", UserName: "", Running: 1, CpusAlloc: 12, MemoryAlloc: 3072 * 1024 * 1024, GpusAlloc: 4},
+					{JobID: "3", JobName: "test_job_3", Nodes: []string{""}, Account: "", Partition: "green", UserID: "1000", UserName: "", Pending: 1, CpusAlloc: 0, MemoryAlloc: 0, GpusAlloc: 0},
 				},
 			},
 		},
@@ -434,18 +352,17 @@ func TestJobCollector_getJobMetrics(t *testing.T) {
 				t.Errorf("jobCollector.getJobMetrics() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			
+
 			// Sort JobIndividualStates for consistent comparison
 			if got != nil {
 				sort.Slice(got.JobIndividualStates, func(i, j int) bool {
 					return got.JobIndividualStates[i].JobID < got.JobIndividualStates[j].JobID
 				})
 			}
-			
+
 			opts := []cmp.Option{
 				cmpopts.IgnoreUnexported(JobMetrics{}),
 				cmpopts.IgnoreFields(JobStates{}, "total"),
-				cmpopts.IgnoreFields(JobTres{}, "total"),
 			}
 			if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
 				t.Errorf("jobCollector.getJobMetrics() = (-want,+got):\n%s", diff)

--- a/internal/collector/partition.go
+++ b/internal/collector/partition.go
@@ -44,14 +44,6 @@ func NewPartitionCollector(slurmClient client.Client) prometheus.Collector {
 			// Other States
 			Hold: prometheus.NewDesc("slurm_partition_jobs_hold_total", "Number of jobs with Hold flag in the partition", partitionLabels, nil),
 		},
-		JobTres: jobTresCollector{
-			// CPUs
-			CpusAlloc: prometheus.NewDesc("slurm_partition_jobs_cpus_alloc_total", "Number of Allocated CPUs among jobs in the partition", partitionLabels, nil),
-			// Memory
-			MemoryAlloc: prometheus.NewDesc("slurm_partition_jobs_memory_alloc_total", "Amount of Allocated Memory (bytes) among jobs in the partition", partitionLabels, nil),
-			// GPUs
-			GpusAlloc: prometheus.NewDesc("slurm_partition_jobs_gpus_alloc_total", "Number of Allocated GPUs among jobs in the partition", partitionLabels, nil),
-		},
 		PendingNodeCount: prometheus.NewDesc("slurm_partition_jobs_pending_maxnodecount_total", "Largest number of nodes required among pending jobs in the partition", partitionLabels, nil),
 		NodeCount:        prometheus.NewDesc("slurm_partition_nodes_total", "Total number of slurm nodes", partitionLabels, nil),
 		NodeStates: nodeStatesCollector{
@@ -95,7 +87,6 @@ type partitionCollector struct {
 
 	JobCount  *prometheus.Desc
 	JobStates jobStatesCollector
-	JobTres   jobTresCollector
 
 	NodeCount  *prometheus.Desc
 	NodeStates nodeStatesCollector
@@ -140,10 +131,6 @@ func (c *partitionCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.JobStates.PowerUpNode, prometheus.GaugeValue, float64(data.JobMetrics.JobStates.PowerUpNode), partition)
 		ch <- prometheus.MustNewConstMetric(c.JobStates.StageOut, prometheus.GaugeValue, float64(data.JobMetrics.JobStates.StageOut), partition)
 		ch <- prometheus.MustNewConstMetric(c.JobStates.Hold, prometheus.GaugeValue, float64(data.JobMetrics.JobStates.Hold), partition)
-		// Tres
-		ch <- prometheus.MustNewConstMetric(c.JobTres.CpusAlloc, prometheus.GaugeValue, float64(data.JobTres.CpusAlloc), partition)
-		ch <- prometheus.MustNewConstMetric(c.JobTres.MemoryAlloc, prometheus.GaugeValue, float64(data.JobTres.MemoryAlloc), partition)
-		ch <- prometheus.MustNewConstMetric(c.JobTres.GpusAlloc, prometheus.GaugeValue, float64(data.JobTres.GpusAlloc), partition)
 		// Other
 		ch <- prometheus.MustNewConstMetric(c.PendingNodeCount, prometheus.GaugeValue, float64(data.PendingNodeCount), partition)
 	}
@@ -230,7 +217,6 @@ func calculatePartitionMetrics(
 			}
 			metrics.JobMetricsPer[key].JobCount++
 			calculateJobState(&metrics.JobMetricsPer[key].JobStates, job)
-			calculateJobTres(&metrics.JobMetricsPer[key].JobTres, job)
 			metrics.JobMetricsPer[key].PendingNodeCount = max(metrics.JobMetricsPer[key].PendingNodeCount, getJobPendingNodeCount(job))
 		}
 	}

--- a/internal/collector/partition_test.go
+++ b/internal/collector/partition_test.go
@@ -142,11 +142,6 @@ func TestPartitionCollector_getPartitionMetrics(t *testing.T) {
 								Running: 1,
 								Hold:    1,
 							},
-							JobTres: JobTres{
-								CpusAlloc:   8,
-								MemoryAlloc: 1024 * 1024 * 1024,
-								GpusAlloc:   2,
-							},
 						},
 						PendingNodeCount: 0,
 					},
@@ -157,11 +152,6 @@ func TestPartitionCollector_getPartitionMetrics(t *testing.T) {
 								Pending: 2,
 								Running: 1,
 								Hold:    1,
-							},
-							JobTres: JobTres{
-								CpusAlloc:   12,
-								MemoryAlloc: 3072 * 1024 * 1024,
-								GpusAlloc:   4,
 							},
 						},
 						PendingNodeCount: 2,
@@ -194,7 +184,6 @@ func TestPartitionCollector_getPartitionMetrics(t *testing.T) {
 			opts := []cmp.Option{
 				cmpopts.IgnoreUnexported(PartitionMetrics{}),
 				cmpopts.IgnoreFields(JobStates{}, "total"),
-				cmpopts.IgnoreFields(JobTres{}, "total"),
 				cmpopts.IgnoreUnexported(NodeMetrics{}),
 				cmpopts.IgnoreFields(NodeStates{}, "total"),
 				cmpopts.IgnoreFields(NodeTres{}, "total"),

--- a/internal/collector/user.go
+++ b/internal/collector/user.go
@@ -43,14 +43,6 @@ func NewUserCollector(slurmClient client.Client) prometheus.Collector {
 			// Other States
 			Hold: prometheus.NewDesc("slurm_user_jobs_hold_total", "Number of user jobs with Hold flag", userLabels, nil),
 		},
-		JobTres: jobTresCollector{
-			// CPUs
-			CpusAlloc: prometheus.NewDesc("slurm_user_jobs_cpus_alloc_total", "Number of Allocated CPUs among user jobs", userLabels, nil),
-			// Memory
-			MemoryAlloc: prometheus.NewDesc("slurm_user_jobs_memory_alloc_total", "Amount of Allocated Memory (bytes) among user jobs", userLabels, nil),
-			// GPUs
-			GpusAlloc: prometheus.NewDesc("slurm_user_jobs_gpus_alloc_total", "Number of Allocated GPUs among user jobs", userLabels, nil),
-		},
 	}
 }
 
@@ -59,7 +51,6 @@ type userCollector struct {
 
 	JobCount  *prometheus.Desc
 	JobStates jobStatesCollector
-	JobTres   jobTresCollector
 }
 
 func (c *userCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -97,10 +88,6 @@ func (c *userCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.JobStates.Configuring, prometheus.GaugeValue, float64(data.JobStates.Configuring), userCtx.UserId, userCtx.UserName)
 		ch <- prometheus.MustNewConstMetric(c.JobStates.PowerUpNode, prometheus.GaugeValue, float64(data.JobStates.PowerUpNode), userCtx.UserId, userCtx.UserName)
 		ch <- prometheus.MustNewConstMetric(c.JobStates.Hold, prometheus.GaugeValue, float64(data.JobStates.Hold), userCtx.UserId, userCtx.UserName)
-		// Tres
-		ch <- prometheus.MustNewConstMetric(c.JobTres.CpusAlloc, prometheus.GaugeValue, float64(data.JobTres.CpusAlloc), userCtx.UserId, userCtx.UserName)
-		ch <- prometheus.MustNewConstMetric(c.JobTres.MemoryAlloc, prometheus.GaugeValue, float64(data.JobTres.MemoryAlloc), userCtx.UserId, userCtx.UserName)
-		ch <- prometheus.MustNewConstMetric(c.JobTres.GpusAlloc, prometheus.GaugeValue, float64(data.JobTres.GpusAlloc), userCtx.UserId, userCtx.UserName)
 	}
 }
 
@@ -132,7 +119,6 @@ func calculateUserMetrics(jobList *types.V0041JobInfoList) *UserMetrics {
 		}
 		metrics.JobMetricsPer[key].JobCount++
 		calculateJobState(&metrics.JobMetricsPer[key].JobStates, job)
-		calculateJobTres(&metrics.JobMetricsPer[key].JobTres, job)
 	}
 	return metrics
 }

--- a/internal/collector/user_test.go
+++ b/internal/collector/user_test.go
@@ -54,12 +54,10 @@ func TestUserCollector_getUserMetrics(t *testing.T) {
 					{UserId: "0", UserName: "root"}: {
 						JobCount:  2,
 						JobStates: JobStates{Pending: 1, Running: 1, Hold: 1},
-						JobTres:   JobTres{CpusAlloc: 8, MemoryAlloc: 1024 * 1024 * 1024, GpusAlloc: 2},
 					},
 					{UserId: "1000"}: {
 						JobCount:  2,
 						JobStates: JobStates{Pending: 1, Running: 1},
-						JobTres:   JobTres{CpusAlloc: 12, MemoryAlloc: 3072 * 1024 * 1024, GpusAlloc: 4},
 					},
 				},
 			},
@@ -89,7 +87,6 @@ func TestUserCollector_getUserMetrics(t *testing.T) {
 			opts := []cmp.Option{
 				cmpopts.IgnoreUnexported(UserMetrics{}),
 				cmpopts.IgnoreFields(JobStates{}, "total"),
-				cmpopts.IgnoreFields(JobTres{}, "total"),
 			}
 			if diff := cmp.Diff(tt.want, got, opts...); diff != "" {
 				t.Errorf("userCollector.getUserMetrics() = (-want,+got):\n%s", diff)


### PR DESCRIPTION
- Remove the metrics that emitted the total amount of resources across all jobs / across an account / across a user / across a partition
- Replace these with per-job metrics that include labels for account/partition/user -- aggregation can be done when querying

This means that we emit more granular information and the dashboards can be better

(the code is also simpler too lol)