### PR TITLE
simplify job state metrics

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -17,4 +17,8 @@ var (
 	combinedStateLabels = []string{"node", "combined_state"}
 
 	jobLabels = []string{"job_id", "job_name", "node", "account", "partition", "user_id", "user_name"}
+
+	jobLabelsWithState = []string{"job_id", "job_name", "node", "account", "partition", "user_id", "user_name", "state", "hold"}
+
+	jobLabelsWithFlag = []string{"job_id", "job_name", "node", "account", "partition", "user_id", "user_name", "flag"}
 )

--- a/internal/collector/job.go
+++ b/internal/collector/job.go
@@ -6,6 +6,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/utils/ptr"
@@ -21,50 +22,10 @@ func NewJobCollector(slurmClient client.Client) prometheus.Collector {
 	return &jobCollector{
 		slurmClient: slurmClient,
 
-		JobCount: prometheus.NewDesc("slurm_jobs_total", "Total number of jobs", nil, nil),
-		JobStates: jobStatesCollector{
-			// Base States
-			BootFail:    prometheus.NewDesc("slurm_jobs_bootfail_total", "Number of jobs in BootFail state", nil, nil),
-			Cancelled:   prometheus.NewDesc("slurm_jobs_cancelled_total", "Number of jobs in Cancelled state", nil, nil),
-			Completed:   prometheus.NewDesc("slurm_jobs_completed_total", "Number of jobs in Completed state", nil, nil),
-			Deadline:    prometheus.NewDesc("slurm_jobs_deadline_total", "Number of jobs in Deadline state", nil, nil),
-			Failed:      prometheus.NewDesc("slurm_jobs_failed_total", "Number of jobs in Failed state", nil, nil),
-			Pending:     prometheus.NewDesc("slurm_jobs_pending_total", "Number of jobs in Pending state", nil, nil),
-			Preempted:   prometheus.NewDesc("slurm_jobs_preempted_total", "Number of jobs in Preempted state", nil, nil),
-			Running:     prometheus.NewDesc("slurm_jobs_running_total", "Number of jobs in Running state", nil, nil),
-			Suspended:   prometheus.NewDesc("slurm_jobs_suspended_total", "Number of jobs in Suspended state", nil, nil),
-			Timeout:     prometheus.NewDesc("slurm_jobs_timeout_total", "Number of jobs in Timeout state", nil, nil),
-			NodeFail:    prometheus.NewDesc("slurm_jobs_nodefail_total", "Number of jobs in NodeFail state", nil, nil),
-			OutOfMemory: prometheus.NewDesc("slurm_jobs_outofmemory_total", "Number of jobs in OutOfMemory state", nil, nil),
-			// Flag States
-			Completing:  prometheus.NewDesc("slurm_jobs_completing_total", "Number of jobs with Completing flag", nil, nil),
-			Configuring: prometheus.NewDesc("slurm_jobs_configuring_total", "Number of jobs with Configuring flag", nil, nil),
-			PowerUpNode: prometheus.NewDesc("slurm_jobs_powerupnode_total", "Number of jobs with PowerUpNode flag", nil, nil),
-			StageOut:    prometheus.NewDesc("slurm_jobs_stageout_total", "Number of jobs with StageOut flag", nil, nil),
-			// Other States
-			Hold: prometheus.NewDesc("slurm_jobs_hold_total", "Number of jobs with Hold flag", nil, nil),
-		},
-		// Individual Job State Metrics
-		// Base States
-		JobStateBootFail:    prometheus.NewDesc("slurm_job_state_bootfail", "The BootFail state of the job", jobLabels, nil),
-		JobStateCancelled:   prometheus.NewDesc("slurm_job_state_cancelled", "The Cancelled state of the job", jobLabels, nil),
-		JobStateCompleted:   prometheus.NewDesc("slurm_job_state_completed", "The Completed state of the job", jobLabels, nil),
-		JobStateDeadline:    prometheus.NewDesc("slurm_job_state_deadline", "The Deadline state of the job", jobLabels, nil),
-		JobStateFailed:      prometheus.NewDesc("slurm_job_state_failed", "The Failed state of the job", jobLabels, nil),
-		JobStatePending:     prometheus.NewDesc("slurm_job_state_pending", "The Pending state of the job", jobLabels, nil),
-		JobStatePreempted:   prometheus.NewDesc("slurm_job_state_preempted", "The Preempted state of the job", jobLabels, nil),
-		JobStateRunning:     prometheus.NewDesc("slurm_job_state_running", "The Running state of the job", jobLabels, nil),
-		JobStateSuspended:   prometheus.NewDesc("slurm_job_state_suspended", "The Suspended state of the job", jobLabels, nil),
-		JobStateTimeout:     prometheus.NewDesc("slurm_job_state_timeout", "The Timeout state of the job", jobLabels, nil),
-		JobStateNodeFail:    prometheus.NewDesc("slurm_job_state_nodefail", "The NodeFail state of the job", jobLabels, nil),
-		JobStateOutOfMemory: prometheus.NewDesc("slurm_job_state_outofmemory", "The OutOfMemory state of the job", jobLabels, nil),
-		// Flag States
-		JobStateCompleting:  prometheus.NewDesc("slurm_job_state_completing", "The Completing state of the job", jobLabels, nil),
-		JobStateConfiguring: prometheus.NewDesc("slurm_job_state_configuring", "The Configuring state of the job", jobLabels, nil),
-		JobStatePowerUpNode: prometheus.NewDesc("slurm_job_state_powerupnode", "The PowerUpNode state of the job", jobLabels, nil),
-		JobStateStageOut:    prometheus.NewDesc("slurm_job_state_stageout", "The StageOut state of the job", jobLabels, nil),
-		// Other States
-		JobStateHold: prometheus.NewDesc("slurm_job_state_hold", "The Hold state of the job", jobLabels, nil),
+		// New unified state metric with state and hold labels
+		JobState: prometheus.NewDesc("slurm_job_state", "The base state of the job", jobLabelsWithState, nil),
+		// New flag metric with concatenated flags
+		JobFlag: prometheus.NewDesc("slurm_job_flag", "The flag states of the job", jobLabelsWithFlag, nil),
 		// Tres
 		JobTres: jobTresCollector{
 			// CPUs
@@ -80,64 +41,16 @@ func NewJobCollector(slurmClient client.Client) prometheus.Collector {
 type jobCollector struct {
 	slurmClient client.Client
 
-	// -------------------------------------------------------------------------
-	// Collective Metrics
-	// -------------------------------------------------------------------------
-	JobCount  *prometheus.Desc
-	JobStates jobStatesCollector
+	// New unified state metric with state and hold labels
+	JobState *prometheus.Desc
 
-	// -------------------------------------------------------------------------
-	// Individual Metrics
-	// -------------------------------------------------------------------------
-
-	// Individual Job State Metrics --------------------------------------------
-	// Base States
-	JobStateBootFail    *prometheus.Desc
-	JobStateCancelled   *prometheus.Desc
-	JobStateCompleted   *prometheus.Desc
-	JobStateDeadline    *prometheus.Desc
-	JobStateFailed      *prometheus.Desc
-	JobStatePending     *prometheus.Desc
-	JobStatePreempted   *prometheus.Desc
-	JobStateRunning     *prometheus.Desc
-	JobStateSuspended   *prometheus.Desc
-	JobStateTimeout     *prometheus.Desc
-	JobStateNodeFail    *prometheus.Desc
-	JobStateOutOfMemory *prometheus.Desc
-	// Flag States
-	JobStateCompleting  *prometheus.Desc
-	JobStateConfiguring *prometheus.Desc
-	JobStatePowerUpNode *prometheus.Desc
-	JobStateStageOut    *prometheus.Desc
-	// Other States
-	JobStateHold *prometheus.Desc
+	// New flag metric with concatenated flags
+	JobFlag *prometheus.Desc
 
 	// Individual Job Tres Metrics ---------------------------------------------
 	JobTres jobTresCollector
 }
 
-type jobStatesCollector struct {
-	// Base States
-	BootFail    *prometheus.Desc
-	Cancelled   *prometheus.Desc
-	Completed   *prometheus.Desc
-	Deadline    *prometheus.Desc
-	Failed      *prometheus.Desc
-	Pending     *prometheus.Desc
-	Preempted   *prometheus.Desc
-	Running     *prometheus.Desc
-	Suspended   *prometheus.Desc
-	Timeout     *prometheus.Desc
-	NodeFail    *prometheus.Desc
-	OutOfMemory *prometheus.Desc
-	// Flag States
-	Completing  *prometheus.Desc
-	Configuring *prometheus.Desc
-	PowerUpNode *prometheus.Desc
-	StageOut    *prometheus.Desc
-	// Other States
-	Hold *prometheus.Desc
-}
 
 type jobTresCollector struct {
 	// CPUs
@@ -164,33 +77,6 @@ func (c *jobCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	// -------------------------------------------------------------------------
-	// Collective Metrics
-	// -------------------------------------------------------------------------
-	// Counts
-	ch <- prometheus.MustNewConstMetric(c.JobCount, prometheus.GaugeValue, float64(metrics.JobCount))
-	// States
-	ch <- prometheus.MustNewConstMetric(c.JobStates.BootFail, prometheus.GaugeValue, float64(metrics.JobStates.BootFail))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Cancelled, prometheus.GaugeValue, float64(metrics.JobStates.Cancelled))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Completed, prometheus.GaugeValue, float64(metrics.JobStates.Completed))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Deadline, prometheus.GaugeValue, float64(metrics.JobStates.Deadline))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Failed, prometheus.GaugeValue, float64(metrics.JobStates.Failed))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Pending, prometheus.GaugeValue, float64(metrics.JobStates.Pending))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Preempted, prometheus.GaugeValue, float64(metrics.JobStates.Preempted))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Running, prometheus.GaugeValue, float64(metrics.JobStates.Running))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Suspended, prometheus.GaugeValue, float64(metrics.JobStates.Suspended))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Timeout, prometheus.GaugeValue, float64(metrics.JobStates.Timeout))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.NodeFail, prometheus.GaugeValue, float64(metrics.JobStates.NodeFail))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.OutOfMemory, prometheus.GaugeValue, float64(metrics.JobStates.OutOfMemory))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Completing, prometheus.GaugeValue, float64(metrics.JobStates.Completing))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Configuring, prometheus.GaugeValue, float64(metrics.JobStates.Configuring))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.PowerUpNode, prometheus.GaugeValue, float64(metrics.JobStates.PowerUpNode))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.StageOut, prometheus.GaugeValue, float64(metrics.JobStates.StageOut))
-	ch <- prometheus.MustNewConstMetric(c.JobStates.Hold, prometheus.GaugeValue, float64(metrics.JobStates.Hold))
-
-	// -------------------------------------------------------------------------
-	// Individual Metrics
-	// -------------------------------------------------------------------------
 
 	for _, jobState := range metrics.JobIndividualStates {
 		jobID := jobState.JobID
@@ -200,62 +86,66 @@ func (c *jobCollector) Collect(ch chan<- prometheus.Metric) {
 		userID := jobState.UserID
 		userName := jobState.UserName
 		for _, node := range jobState.Nodes {
-			// Individual Job State Metrics ------------------------------------
-			// Only emit when state is active (value = 1) for cardinality reasons.
-
-			// Base States
-			if jobState.BootFail == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateBootFail, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
+			// New unified state metric with state and hold labels --------------
+			// Determine the base state name
+			var stateName string
+			// Check base states (these are mutually exclusive)
+			switch {
+			case jobState.BootFail == 1:
+				stateName = "bootfail"
+			case jobState.Cancelled == 1:
+				stateName = "cancelled"
+			case jobState.Completed == 1:
+				stateName = "completed"
+			case jobState.Deadline == 1:
+				stateName = "deadline"
+			case jobState.Failed == 1:
+				stateName = "failed"
+			case jobState.Pending == 1:
+				stateName = "pending"
+			case jobState.Preempted == 1:
+				stateName = "preempted"
+			case jobState.Running == 1:
+				stateName = "running"
+			case jobState.Suspended == 1:
+				stateName = "suspended"
+			case jobState.Timeout == 1:
+				stateName = "timeout"
+			case jobState.NodeFail == 1:
+				stateName = "nodefail"
+			case jobState.OutOfMemory == 1:
+				stateName = "outofmemory"
+			default:
+				stateName = "unknown"
 			}
-			if jobState.Cancelled == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateCancelled, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
+			
+			// Determine hold status
+			holdStatus := "false"
+			if jobState.Hold == 1 {
+				holdStatus = "true"
 			}
-			if jobState.Completed == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateCompleted, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.Deadline == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateDeadline, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.Failed == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateFailed, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.Pending == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStatePending, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.Preempted == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStatePreempted, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.Running == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateRunning, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.Suspended == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateSuspended, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.Timeout == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateTimeout, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.NodeFail == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateNodeFail, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			if jobState.OutOfMemory == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateOutOfMemory, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
-			}
-			// Flag States
+			
+			ch <- prometheus.MustNewConstMetric(c.JobState, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName, stateName, holdStatus)
+			
+			// New flag metric with concatenated flags --------------------------
+			var flags []string
 			if jobState.Completing == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateCompleting, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
+				flags = append(flags, "completing")
 			}
 			if jobState.Configuring == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateConfiguring, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
+				flags = append(flags, "configuring")
 			}
 			if jobState.PowerUpNode == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStatePowerUpNode, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
+				flags = append(flags, "powerupnode")
 			}
 			if jobState.StageOut == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateStageOut, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
+				flags = append(flags, "stageout")
 			}
-			// Other States
-			if jobState.Hold == 1 {
-				ch <- prometheus.MustNewConstMetric(c.JobStateHold, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName)
+			
+			// Only emit flag metric if there are flags
+			if len(flags) > 0 {
+				flagStr := strings.Join(flags, "+")
+				ch <- prometheus.MustNewConstMetric(c.JobFlag, prometheus.GaugeValue, 1, jobID, jobName, node, account, partition, userID, userName, flagStr)
 			}
 
 			// Individual Job Tres Metrics -------------------------------------
@@ -403,6 +293,30 @@ type JobStates struct {
 	// Other States
 	Hold uint
 }
+
+type jobStatesCollector struct {
+	// Base States
+	BootFail    *prometheus.Desc
+	Cancelled   *prometheus.Desc
+	Completed   *prometheus.Desc
+	Deadline    *prometheus.Desc
+	Failed      *prometheus.Desc
+	Pending     *prometheus.Desc
+	Preempted   *prometheus.Desc
+	Running     *prometheus.Desc
+	Suspended   *prometheus.Desc
+	Timeout     *prometheus.Desc
+	NodeFail    *prometheus.Desc
+	OutOfMemory *prometheus.Desc
+	// Flag States
+	Completing  *prometheus.Desc
+	Configuring *prometheus.Desc
+	PowerUpNode *prometheus.Desc
+	StageOut    *prometheus.Desc
+	// Other States
+	Hold *prometheus.Desc
+}
+
 
 type JobIndividualStates struct {
 	JobID     string

--- a/internal/collector/job_test.go
+++ b/internal/collector/job_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/utils/ptr"
@@ -79,211 +80,6 @@ func Test_getJobResourceAlloc(t *testing.T) {
 	}
 }
 
-func Test_calculateJobState(t *testing.T) {
-	type args struct {
-		job types.V0041JobInfo
-	}
-	tests := []struct {
-		name string
-		args args
-		want *JobStates
-	}{
-		{
-			name: "empty",
-			want: &JobStates{},
-		},
-		{
-			name: "boot fail",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateBOOTFAIL,
-					}),
-				}},
-			},
-			want: &JobStates{BootFail: 1},
-		},
-		{
-			name: "cancelled",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateCANCELLED,
-					}),
-				}},
-			},
-			want: &JobStates{Cancelled: 1},
-		},
-		{
-			name: "completed",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateCOMPLETED,
-					}),
-				}},
-			},
-			want: &JobStates{Completed: 1},
-		},
-		{
-			name: "deadline",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateDEADLINE,
-					}),
-				}},
-			},
-			want: &JobStates{Deadline: 1},
-		},
-		{
-			name: "failed",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateFAILED,
-					}),
-				}},
-			},
-			want: &JobStates{Failed: 1},
-		},
-		{
-			name: "pending",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStatePENDING,
-					}),
-				}},
-			},
-			want: &JobStates{Pending: 1},
-		},
-		{
-			name: "preempted",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStatePREEMPTED,
-					}),
-				}},
-			},
-			want: &JobStates{Preempted: 1},
-		},
-		{
-			name: "running",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateRUNNING,
-					}),
-				}},
-			},
-			want: &JobStates{Running: 1},
-		},
-		{
-			name: "suspended",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateSUSPENDED,
-					}),
-				}},
-			},
-			want: &JobStates{Suspended: 1},
-		},
-		{
-			name: "timeout",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateTIMEOUT,
-					}),
-				}},
-			},
-			want: &JobStates{Timeout: 1},
-		},
-		{
-			name: "node fail",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateNODEFAIL,
-					}),
-				}},
-			},
-			want: &JobStates{NodeFail: 1},
-		},
-		{
-			name: "out of memory",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateOUTOFMEMORY,
-					}),
-				}},
-			},
-			want: &JobStates{OutOfMemory: 1},
-		},
-		{
-			name: "all states, all flags",
-			args: args{
-				job: types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
-					JobState: ptr.To([]api.V0041JobInfoJobState{
-						api.V0041JobInfoJobStateBOOTFAIL,
-						api.V0041JobInfoJobStateCANCELLED,
-						api.V0041JobInfoJobStateCOMPLETED,
-						api.V0041JobInfoJobStateCOMPLETING,
-						api.V0041JobInfoJobStateCONFIGURING,
-						api.V0041JobInfoJobStateDEADLINE,
-						api.V0041JobInfoJobStateFAILED,
-						api.V0041JobInfoJobStateLAUNCHFAILED,
-						api.V0041JobInfoJobStateNODEFAIL,
-						api.V0041JobInfoJobStateOUTOFMEMORY,
-						api.V0041JobInfoJobStatePENDING,
-						api.V0041JobInfoJobStatePOWERUPNODE,
-						api.V0041JobInfoJobStatePREEMPTED,
-						api.V0041JobInfoJobStateRECONFIGFAIL,
-						api.V0041JobInfoJobStateREQUEUED,
-						api.V0041JobInfoJobStateREQUEUEFED,
-						api.V0041JobInfoJobStateREQUEUEHOLD,
-						api.V0041JobInfoJobStateRESIZING,
-						api.V0041JobInfoJobStateRESVDELHOLD,
-						api.V0041JobInfoJobStateREVOKED,
-						api.V0041JobInfoJobStateRUNNING,
-						api.V0041JobInfoJobStateSIGNALING,
-						api.V0041JobInfoJobStateSPECIALEXIT,
-						api.V0041JobInfoJobStateSTAGEOUT,
-						api.V0041JobInfoJobStateSTOPPED,
-						api.V0041JobInfoJobStateSUSPENDED,
-						api.V0041JobInfoJobStateTIMEOUT,
-						api.V0041JobInfoJobStateUPDATEDB,
-					}),
-					Hold: ptr.To(true),
-				}},
-			},
-			want: &JobStates{
-				BootFail:    1,
-				Completing:  1,
-				Configuring: 1,
-				PowerUpNode: 1,
-				StageOut:    1,
-				Hold:        1,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			metrics := &JobStates{}
-			calculateJobState(metrics, tt.args.job)
-			opts := []cmp.Option{
-				cmpopts.IgnoreUnexported(JobStates{}),
-			}
-			if diff := cmp.Diff(tt.want, metrics, opts...); diff != "" {
-				t.Errorf("calculateJobState() = (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
 
 func TestJobCollector_getJobMetrics(t *testing.T) {
 	type fields struct {
@@ -465,6 +261,235 @@ func TestJobCollector_Describe(t *testing.T) {
 			var desc *prometheus.Desc
 			for desc = range tt.args.ch {
 				assert.NotNil(t, desc)
+			}
+		})
+	}
+}
+
+func TestJobCollector_JobStateMetric(t *testing.T) {
+	// Create a job collector with test data
+	c := NewJobCollector(testDataClient)
+	ch := make(chan prometheus.Metric, 100)
+	
+	// Collect metrics
+	c.Collect(ch)
+	close(ch)
+	
+	// Track found metrics
+	foundStates := make(map[string]bool)
+	expectedStates := map[string]struct {
+		state string
+		hold  string
+	}{
+		"0": {state: "running", hold: "false"},  // job0 is RUNNING
+		"1": {state: "pending", hold: "true"},   // job1 is PENDING with Hold=true
+		"2": {state: "running", hold: "false"},  // job2 is RUNNING
+		"3": {state: "pending", hold: "false"},  // job3 is PENDING
+	}
+	
+	// Check all metrics
+	for metric := range ch {
+		metricDto := &dto.Metric{}
+		err := metric.Write(metricDto)
+		assert.NoError(t, err)
+		
+		// Look for slurm_job_state metrics
+		if metricDto.Label != nil {
+			// Check if this is our new metric by looking for the state label
+			var hasStateLabel, hasHoldLabel bool
+			var jobID, stateName, holdValue string
+			
+			for _, label := range metricDto.Label {
+				if label.GetName() == "state" {
+					hasStateLabel = true
+					stateName = label.GetValue()
+				}
+				if label.GetName() == "hold" {
+					hasHoldLabel = true
+					holdValue = label.GetValue()
+				}
+				if label.GetName() == "job_id" {
+					jobID = label.GetValue()
+				}
+			}
+			
+			if hasStateLabel && hasHoldLabel {
+				// Verify the state and hold value match expected
+				if expected, ok := expectedStates[jobID]; ok {
+					assert.Equal(t, expected.state, stateName, "Job %s should have state %s", jobID, expected.state)
+					assert.Equal(t, expected.hold, holdValue, "Job %s should have hold %s", jobID, expected.hold)
+					foundStates[jobID] = true
+				}
+			}
+		}
+	}
+	
+	// Ensure we found all expected job states
+	for jobID := range expectedStates {
+		assert.True(t, foundStates[jobID], "Did not find slurm_job_state metric for job %s", jobID)
+	}
+}
+
+func TestJobStateMetric_AllStates(t *testing.T) {
+	// Test that all possible states are handled correctly
+	testCases := []struct {
+		name          string
+		jobState      []api.V0041JobInfoJobState
+		hold          bool
+		expectedState string
+		expectedHold  string
+	}{
+		{"bootfail", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateBOOTFAIL}, false, "bootfail", "false"},
+		{"cancelled", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateCANCELLED}, false, "cancelled", "false"},
+		{"completed", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateCOMPLETED}, false, "completed", "false"},
+		{"deadline", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateDEADLINE}, false, "deadline", "false"},
+		{"failed", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateFAILED}, false, "failed", "false"},
+		{"pending", []api.V0041JobInfoJobState{api.V0041JobInfoJobStatePENDING}, false, "pending", "false"},
+		{"pending_with_hold", []api.V0041JobInfoJobState{api.V0041JobInfoJobStatePENDING}, true, "pending", "true"},
+		{"preempted", []api.V0041JobInfoJobState{api.V0041JobInfoJobStatePREEMPTED}, false, "preempted", "false"},
+		{"running", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateRUNNING}, false, "running", "false"},
+		{"suspended", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateSUSPENDED}, false, "suspended", "false"},
+		{"timeout", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateTIMEOUT}, false, "timeout", "false"},
+		{"nodefail", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateNODEFAIL}, false, "nodefail", "false"},
+		{"outofmemory", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateOUTOFMEMORY}, false, "outofmemory", "false"},
+		{"unknown", []api.V0041JobInfoJobState{}, false, "unknown", "false"},
+		{"unknown_with_hold", []api.V0041JobInfoJobState{}, true, "unknown", "true"},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test job with the specified state
+			testJob := &types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
+				JobId:    ptr.To[int32](999),
+				Name:     ptr.To("test_state_job"),
+				JobState: ptr.To(tc.jobState),
+				Hold:     ptr.To(tc.hold),
+				UserId:   ptr.To[int32](0),
+				UserName: ptr.To("root"),
+				Account:  ptr.To("test"),
+				Partition: ptr.To("test"),
+			}}
+			
+			// Create a fake client with just this job
+			jobList := &types.V0041JobInfoList{
+				Items: []types.V0041JobInfo{*testJob},
+			}
+			client := fake.NewClientBuilder().WithLists(jobList).Build()
+			
+			// Create collector and collect metrics
+			c := NewJobCollector(client)
+			ch := make(chan prometheus.Metric, 100)
+			c.Collect(ch)
+			close(ch)
+			
+			// Find the slurm_job_state metric
+			var foundState, foundHold string
+			for metric := range ch {
+				metricDto := &dto.Metric{}
+				err := metric.Write(metricDto)
+				assert.NoError(t, err)
+				
+				var hasState, hasHold bool
+				for _, label := range metricDto.Label {
+					if label.GetName() == "state" {
+						foundState = label.GetValue()
+						hasState = true
+					}
+					if label.GetName() == "hold" {
+						foundHold = label.GetValue()
+						hasHold = true
+					}
+				}
+				
+				if hasState && hasHold {
+					break
+				}
+			}
+			
+			assert.Equal(t, tc.expectedState, foundState, "Expected state %s for test case %s", tc.expectedState, tc.name)
+			assert.Equal(t, tc.expectedHold, foundHold, "Expected hold %s for test case %s", tc.expectedHold, tc.name)
+		})
+	}
+}
+
+func TestJobFlagMetric(t *testing.T) {
+	// Test flag concatenation
+	testCases := []struct {
+		name         string
+		jobState     []api.V0041JobInfoJobState
+		expectedFlag string
+		shouldEmit   bool
+	}{
+		{"no_flags", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateRUNNING}, "", false},
+		{"completing", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateRUNNING, api.V0041JobInfoJobStateCOMPLETING}, "completing", true},
+		{"configuring", []api.V0041JobInfoJobState{api.V0041JobInfoJobStatePENDING, api.V0041JobInfoJobStateCONFIGURING}, "configuring", true},
+		{"powerupnode", []api.V0041JobInfoJobState{api.V0041JobInfoJobStatePENDING, api.V0041JobInfoJobStatePOWERUPNODE}, "powerupnode", true},
+		{"stageout", []api.V0041JobInfoJobState{api.V0041JobInfoJobStateRUNNING, api.V0041JobInfoJobStateSTAGEOUT}, "stageout", true},
+		{"multiple_flags", []api.V0041JobInfoJobState{
+			api.V0041JobInfoJobStateRUNNING,
+			api.V0041JobInfoJobStateCOMPLETING,
+			api.V0041JobInfoJobStateSTAGEOUT,
+		}, "completing+stageout", true},
+		{"all_flags", []api.V0041JobInfoJobState{
+			api.V0041JobInfoJobStatePENDING,
+			api.V0041JobInfoJobStateCOMPLETING,
+			api.V0041JobInfoJobStateCONFIGURING,
+			api.V0041JobInfoJobStatePOWERUPNODE,
+			api.V0041JobInfoJobStateSTAGEOUT,
+		}, "completing+configuring+powerupnode+stageout", true},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test job with the specified states
+			testJob := &types.V0041JobInfo{V0041JobInfo: api.V0041JobInfo{
+				JobId:     ptr.To[int32](999),
+				Name:      ptr.To("test_flag_job"),
+				JobState:  ptr.To(tc.jobState),
+				UserId:    ptr.To[int32](0),
+				UserName:  ptr.To("root"),
+				Account:   ptr.To("test"),
+				Partition: ptr.To("test"),
+			}}
+			
+			// Create a fake client with just this job
+			jobList := &types.V0041JobInfoList{
+				Items: []types.V0041JobInfo{*testJob},
+			}
+			client := fake.NewClientBuilder().WithLists(jobList).Build()
+			
+			// Create collector and collect metrics
+			c := NewJobCollector(client)
+			ch := make(chan prometheus.Metric, 100)
+			c.Collect(ch)
+			close(ch)
+			
+			// Find the slurm_job_flag metric
+			var foundFlag string
+			var foundFlagMetric bool
+			for metric := range ch {
+				metricDto := &dto.Metric{}
+				err := metric.Write(metricDto)
+				assert.NoError(t, err)
+				
+				for _, label := range metricDto.Label {
+					if label.GetName() == "flag" {
+						foundFlag = label.GetValue()
+						foundFlagMetric = true
+						break
+					}
+				}
+				
+				if foundFlagMetric {
+					break
+				}
+			}
+			
+			if tc.shouldEmit {
+				assert.True(t, foundFlagMetric, "Expected flag metric to be emitted for test case %s", tc.name)
+				assert.Equal(t, tc.expectedFlag, foundFlag, "Expected flag %s for test case %s", tc.expectedFlag, tc.name)
+			} else {
+				assert.False(t, foundFlagMetric, "Expected no flag metric for test case %s", tc.name)
 			}
 		})
 	}


### PR DESCRIPTION
- Replace all the individual state and flag metrics with two simpler metrics (one for states, another for flags), that have a label containing the state value.
    - The flag metric concats the flags together, since there can be multiple.

Since these metrics have user/account/partition labels on them, they can replace the user/account/partition metrics as well. But I'm leaving them in for now, for backwards compatability reasons (removing all the old job metrics is enough work right now and I don't want *all* graphs to break all at once).