### PR TITLE
chore(slurm-exporter): add node state reason and user audit to slurm_state_combined

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -14,7 +14,7 @@ var (
 
 	partitionLabels = []string{"partition"}
 
-	combinedStateLabels = []string{"node", "combined_state"}
+	combinedStateLabels = []string{"node", "combined_state", "reason", "user"}
 
 	jobLabels = []string{"job_id", "job_name", "node", "account", "partition", "user_id", "user_name"}
 

--- a/internal/collector/node.go
+++ b/internal/collector/node.go
@@ -209,7 +209,7 @@ func (c *nodeCollector) Collect(ch chan<- prometheus.Metric) {
 
 	// Combined Node State Metrics
 	for node, state := range metrics.NodeCombinedStates {
-		ch <- prometheus.MustNewConstMetric(c.NodeCombinedState, prometheus.GaugeValue, float64(state.Unavailable), node, state.CombinedState)
+		ch <- prometheus.MustNewConstMetric(c.NodeCombinedState, prometheus.GaugeValue, float64(state.Unavailable), node, state.CombinedState, state.Reason, state.User)
 	}
 
 	// Individual Node State Metrics - only emit when state is active (value = 1)
@@ -433,6 +433,8 @@ type NodeCollectorMetrics struct {
 type NodeCombinedState struct {
 	CombinedState string
 	Unavailable   int
+	Reason        string
+	User          string
 }
 
 type NodeIndividualStates struct {
@@ -637,6 +639,8 @@ func calculateNodeCombinedState(node types.V0041Node) *NodeCombinedState {
 	return &NodeCombinedState{
 		CombinedState: combinedState,
 		Unavailable:   unavailable,
+		Reason:        ptr.Deref(node.Reason, ""),
+		User:          ptr.Deref(node.ReasonSetByUser, ""),
 	}
 }
 

--- a/internal/collector/node_test.go
+++ b/internal/collector/node_test.go
@@ -195,6 +195,8 @@ func Test_calculateNodeCombinedState(t *testing.T) {
 			want: &NodeCombinedState{
 				CombinedState: "idle",
 				Unavailable:   0,
+				Reason:        "",
+				User:          "",
 			},
 		},
 		{
@@ -209,6 +211,8 @@ func Test_calculateNodeCombinedState(t *testing.T) {
 			want: &NodeCombinedState{
 				CombinedState: "down",
 				Unavailable:   1,
+				Reason:        "",
+				User:          "",
 			},
 		},
 		{
@@ -224,6 +228,8 @@ func Test_calculateNodeCombinedState(t *testing.T) {
 			want: &NodeCombinedState{
 				CombinedState: "drain+mixed",
 				Unavailable:   0, // drain + mixed = available
+				Reason:        "",
+				User:          "",
 			},
 		},
 		{
@@ -239,10 +245,29 @@ func Test_calculateNodeCombinedState(t *testing.T) {
 			want: &NodeCombinedState{
 				CombinedState: "allocated+drain",
 				Unavailable:   0, // drain + allocated = available
+				Reason:        "",
+				User:          "",
 			},
 		},
 		{
-			name: "multiple states",
+			name: "idle+planned",
+			args: args{
+				node: types.V0041Node{V0041Node: api.V0041Node{
+					State: ptr.To([]api.V0041NodeState{
+						api.V0041NodeStateIDLE,
+						api.V0041NodeStatePLANNED,
+					}),
+				}},
+			},
+			want: &NodeCombinedState{
+				CombinedState: "idle+planned",
+				Unavailable:   0,
+				Reason:        "",
+				User:          "",
+			},
+		},
+		{
+			name: "idle+planned+reserved",
 			args: args{
 				node: types.V0041Node{V0041Node: api.V0041Node{
 					State: ptr.To([]api.V0041NodeState{
@@ -254,7 +279,46 @@ func Test_calculateNodeCombinedState(t *testing.T) {
 			},
 			want: &NodeCombinedState{
 				CombinedState: "idle+planned+reserved",
+				Unavailable:   0,
+				Reason:        "",
+				User:          "",
+			},
+		},
+		{
+			name: "down with reason and user",
+			args: args{
+				node: types.V0041Node{V0041Node: api.V0041Node{
+					State: ptr.To([]api.V0041NodeState{
+						api.V0041NodeStateDOWN,
+					}),
+					Reason:          ptr.To("hardware failure"),
+					ReasonSetByUser: ptr.To("admin"),
+				}},
+			},
+			want: &NodeCombinedState{
+				CombinedState: "down",
 				Unavailable:   1,
+				Reason:        "hardware failure",
+				User:          "admin",
+			},
+		},
+		{
+			name: "drain+mixed with reason",
+			args: args{
+				node: types.V0041Node{V0041Node: api.V0041Node{
+					State: ptr.To([]api.V0041NodeState{
+						api.V0041NodeStateMIXED,
+						api.V0041NodeStateDRAIN,
+					}),
+					Reason:          ptr.To("maintenance"),
+					ReasonSetByUser: ptr.To("ops"),
+				}},
+			},
+			want: &NodeCombinedState{
+				CombinedState: "drain+mixed",
+				Unavailable:   0,
+				Reason:        "maintenance",
+				User:          "ops",
 			},
 		},
 	}
@@ -474,18 +538,26 @@ func TestNodeCollector_getNodeMetrics(t *testing.T) {
 					"node0": {
 						CombinedState: "idle",
 						Unavailable:   0,
+						Reason:        "",
+						User:          "",
 					},
 					"node1": {
 						CombinedState: "allocated",
 						Unavailable:   0,
+						Reason:        "",
+						User:          "",
 					},
 					"node2": {
 						CombinedState: "allocated+drain",
 						Unavailable:   0,
+						Reason:        "",
+						User:          "",
 					},
 					"node3": {
 						CombinedState: "completing+mixed",
 						Unavailable:   0,
+						Reason:        "",
+						User:          "",
 					},
 				},
 				NodeIndividualStates: map[string]*NodeIndividualStates{


### PR DESCRIPTION
### TL;DR

Added reason and user information to node combined state metrics to provide more context about node states.

### What changed?

- Added `reason` and `user` labels to the `combinedStateLabels` slice
- Updated the `NodeCombinedState` struct to include `Reason` and `User` fields
- Modified the `calculateNodeCombinedState` function to populate these new fields from node data
- Updated the `Collect` method to include reason and user information when creating metrics
- Added test cases to verify the new fields are properly populated

### How to test?

1. Deploy the updated exporter
2. Query the node combined state metrics and verify that reason and user information is included
3. Check that nodes with specific reasons (like maintenance or hardware failure) show the correct reason and user who set it
4. Verify that the metrics continue to report the correct combined state values

### Why make this change?

This enhancement provides more context about why nodes are in specific states, making it easier to diagnose issues. By including the reason and the user who set it, operators can quickly understand why a node is down, drained, or in another state without having to check other systems. This additional information is particularly valuable for automated monitoring and alerting systems.